### PR TITLE
Issue #7 への対応

### DIFF
--- a/devenv/buildenv.sh
+++ b/devenv/buildenv.sh
@@ -2,9 +2,17 @@
 
 BASEDIR="$HOME/osbook/devenv/x86_64-elf"
 EDK2DIR="$HOME/edk2"
-export CPPFLAGS="\
--I$BASEDIR/include/c++/v1 -I$BASEDIR/include -I$BASEDIR/include/freetype2 \
--I$EDK2DIR/MdePkg/Include -I$EDK2DIR/MdePkg/Include/X64 \
--nostdlibinc -D__ELF__ -D_LDBL_EQ_DBL -D_GNU_SOURCE -D_POSIX_TIMERS \
--DEFIAPI='__attribute__((ms_abi))'"
-export LDFLAGS="-L$BASEDIR/lib"
+
+if [ ! -d $BASEDIR ]
+then
+    echo "$BASEDIR が存在しません."
+    echo "以下のファイルを手動でダウンロードし，$HOME/osbook/devenv/に展開してください．"
+    echo "https://github.com/uchan-nos/mikanos-build/releases/download/v2.0/x86_64-elf.tar.gz "
+else
+    export CPPFLAGS="\
+    -I$BASEDIR/include/c++/v1 -I$BASEDIR/include -I$BASEDIR/include/freetype2 \
+    -I$EDK2DIR/MdePkg/Include -I$EDK2DIR/MdePkg/Include/X64 \
+    -nostdlibinc -D__ELF__ -D_LDBL_EQ_DBL -D_GNU_SOURCE -D_POSIX_TIMERS \
+    -DEFIAPI='__attribute__((ms_abi))'"
+    export LDFLAGS="-L$BASEDIR/lib"
+fi

--- a/devenv/buildenv.sh
+++ b/devenv/buildenv.sh
@@ -5,8 +5,8 @@ EDK2DIR="$HOME/edk2"
 
 if [ ! -d $BASEDIR ]
 then
-    echo "$BASEDIR が存在しません."
-    echo "以下のファイルを手動でダウンロードし，$HOME/osbook/devenv/に展開してください．"
+    echo "$BASEDIR が存在しません。"
+    echo "以下のファイルを手動でダウンロードし、$(dirname $BASEDIR)に展開してください。"
     echo "https://github.com/uchan-nos/mikanos-build/releases/download/v2.0/x86_64-elf.tar.gz "
 else
     export CPPFLAGS="\
@@ -16,3 +16,4 @@ else
     -DEFIAPI='__attribute__((ms_abi))'"
     export LDFLAGS="-L$BASEDIR/lib"
 fi
+


### PR DESCRIPTION
`source buidenv.sh` 実行時に `$HOME/osbook/devenv/x86_64-elf` が存在しない場合，
手動でダウンロードする旨のメッセージを表示するように修正．